### PR TITLE
Add PostgreSQL scoring and DNS service support

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"log"
 	"time"
 
@@ -62,7 +62,7 @@ func SetupSchema(cfg Config, schemaFilePath string) error {
 	defer db.Close()
 
 	// Read the schema SQL from file
-	schema, err := ioutil.ReadFile(schemaFilePath)
+	schema, err := os.ReadFile(schemaFilePath)
 	if err != nil {
 		return fmt.Errorf("failed to read schema file: %w", err)
 	}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,7 +1,7 @@
 -- Database: scoring
 
 -- Teams Table
-CREATE TABLE teams (
+CREATE TABLE IF NOT EXISTS teams (
     team_id SERIAL PRIMARY KEY,
     team_name VARCHAR(50) UNIQUE NOT NULL,
     team_password TEXT NOT NULL,
@@ -9,7 +9,7 @@ CREATE TABLE teams (
 );
 
 -- Services Table
-CREATE TABLE services (
+CREATE TABLE IF NOT EXISTS services (
     service_id SERIAL PRIMARY KEY,
     service_name VARCHAR(50) NOT NULL,
     box_name VARCHAR(50) NOT NULL,
@@ -18,7 +18,7 @@ CREATE TABLE services (
 );
 
 -- Team Services Table (associates teams with their services)
-CREATE TABLE team_services (
+CREATE TABLE IF NOT EXISTS team_services (
     team_service_id SERIAL PRIMARY KEY,
     team_id INT REFERENCES teams(team_id) ON DELETE CASCADE,
     service_id INT REFERENCES services(service_id) ON DELETE CASCADE,
@@ -30,7 +30,7 @@ CREATE TABLE team_services (
 );
 
 -- A table that stores all updates for each team-service combination for reference on frontend
-CREATE TABLE service_checks (
+CREATE TABLE IF NOT EXISTS service_checks (
     check_id SERIAL PRIMARY KEY,
     team_service_id INT REFERENCES team_services(team_service_id) ON DELETE CASCADE,
     status BOOLEAN NOT NULL,           -- true = up, false = down
@@ -38,12 +38,12 @@ CREATE TABLE service_checks (
 );
 
 -- Admin User Table
-CREATE TABLE admin_users (
+CREATE TABLE IF NOT EXISTS admin_users (
     name TEXT PRIMARY KEY,
     password TEXT NOT NULL
 );
 
-CREATE TABLE announcements (
+CREATE TABLE IF NOT EXISTS announcements (
     announcement_id SERIAL PRIMARY KEY,            -- Unique ID for each announcement
     title VARCHAR(255) NOT NULL,                   -- Title of the announcement
     content TEXT NOT NULL,                         -- Main content/body of the announcement
@@ -53,6 +53,6 @@ CREATE TABLE announcements (
 );
 
 -- Indexes for optimized lookups
-CREATE INDEX idx_team_services_team_id ON team_services(team_id);
-CREATE INDEX idx_team_services_service_id ON team_services(service_id);
-CREATE INDEX idx_service_checks_team_service ON service_checks(team_service_id, timestamp DESC);
+CREATE INDEX IF NOT EXISTS idx_team_services_team_id ON team_services(team_id);
+CREATE INDEX IF NOT EXISTS idx_team_services_service_id ON team_services(service_id);
+CREATE INDEX IF NOT EXISTS idx_service_checks_team_service ON service_checks(team_service_id, timestamp DESC);

--- a/scoring/db.go
+++ b/scoring/db.go
@@ -45,17 +45,10 @@ func DBconnect(address string, portNum int, username string, password string, DB
 }
 
 func DBverify(addr string, portNum int, username string, password string, DBName string, DBPath string) (bool, error) {
-	// Open the .sql file
-	file, err := os.Open(DBPath)
-	if err != nil {
-		return false, fmt.Errorf("Failed to open file $v\n", err)
-	}
-	defer file.Close()
-
 	// Read all lines from the file
 	content, err := os.ReadFile(DBPath)
 	if err != nil {
-		return false, fmt.Errorf("Failed to read file $v\n", err)
+		return false, fmt.Errorf("failed to read file: %v", err)
 	}
 
 	lines := strings.Split(string(content), "\n")
@@ -70,11 +63,10 @@ func DBverify(addr string, portNum int, username string, password string, DBName
 	}
 
 	if len(validLines) == 0 {
-		return false, fmt.Errorf("No valid SQL statements found in the file.")
+		return false, fmt.Errorf("no valid SQL statements found in the file")
 	}
 
 	// Pick a random line
-	rand.Seed(time.Now().UnixNano())
 	query := validLines[rand.Intn(len(validLines))]
 
 	// Create a connection string
@@ -83,8 +75,7 @@ func DBverify(addr string, portNum int, username string, password string, DBName
 	// Connect to the database
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		fmt.Printf("Failed to connect to database: %v\n", err)
-		return false, fmt.Errorf("Failed to connect to the database: %v\n", err)
+		return false, fmt.Errorf("failed to connect to the database: %v", err)
 	}
 	defer db.Close()
 
@@ -95,8 +86,7 @@ func DBverify(addr string, portNum int, username string, password string, DBName
 	// Execute the query
 	_, err = db.ExecContext(ctx, query)
 	if err != nil {
-		fmt.Printf("Failed to execute query: %v\n", err)
-		return false, fmt.Errorf("Failed to execute query: %v\n", err)
+		return false, fmt.Errorf("failed to execute query: %v", err)
 	}
 
 	return true, nil

--- a/scoring/ftp.go
+++ b/scoring/ftp.go
@@ -57,7 +57,6 @@ func ftpConnect(address string, portNum int, username string, password string) (
 	}
 
 	// Randomly pick one filename from our global ftpFiles map
-	rand.Seed(time.Now().UnixNano()) // seed RNG once per run; or do this in an init()
 	var fileNames []string
 	for name := range ftpFiles {
 		fileNames = append(fileNames, name)

--- a/scoring/postgres.go
+++ b/scoring/postgres.go
@@ -1,0 +1,89 @@
+package scoring
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+// PGconnect connects to a PostgreSQL database on the target host and verifies
+// the schema by running a random query from the provided query file.
+func PGconnect(address string, portNum int, username string, password string, DBName string, DBPath string) (bool, error) {
+	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable connect_timeout=1",
+		address, portNum, username, password, DBName)
+
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return false, err
+	}
+	defer db.Close()
+
+	// Test the connection
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		return false, err
+	}
+
+	// Verify the database by running a random query from the query file
+	isValid, err := PGverify(db, DBPath)
+	if err != nil {
+		return false, fmt.Errorf("database verification failed: %w", err)
+	}
+
+	if !isValid {
+		return false, fmt.Errorf("database verification returned invalid")
+	}
+
+	return true, nil
+}
+
+// PGverify reads a query file, picks a random SQL statement, and executes it
+// against the already-open PostgreSQL connection.
+func PGverify(db *sql.DB, DBPath string) (bool, error) {
+	content, err := os.ReadFile(DBPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to read file: %v", err)
+	}
+
+	lines := strings.Split(string(content), "\n")
+	var validLines []string
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			validLines = append(validLines, trimmed)
+		}
+	}
+
+	if len(validLines) == 0 {
+		return false, fmt.Errorf("no valid SQL statements found in the file")
+	}
+
+	query := validLines[rand.Intn(len(validLines))]
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	_, err = db.ExecContext(ctx, query)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute query: %v", err)
+	}
+
+	return true, nil
+}
+
+// ScorePostgres checks a PostgreSQL service on the target host and assigns points.
+func ScorePostgres(address string, portNum int, username string, password string, DBName string, DBPath string) (int, bool, error) {
+	_, err := PGconnect(address, portNum, username, password, DBName, DBPath)
+	if err != nil {
+		return 0, false, fmt.Errorf("PostgreSQL scoring failed: %v", err)
+	}
+	return successPoints, true, nil
+}

--- a/scoring/scoring.go
+++ b/scoring/scoring.go
@@ -93,8 +93,8 @@ func ScoringStartup(cfg database.Config, yamlConfig *config.Yaml) error {
 	for range ticker.C {
 		if ScoringOn {
 			rounds++
-			err := RunScoring(db, yamlConfig)
 			start_time := time.Now()
+			err := RunScoring(db, yamlConfig)
 			if err != nil {
 				fmt.Printf("Error running scoring: %v\n", err)
 			}
@@ -228,18 +228,11 @@ func RunScoring(db *sql.DB, yamlConfig *config.Yaml) error {
 				continue
 			}
 
-			// Pass relevant details including fourth_octet, but not the full IP address
-			// TODO: Update this interiorip stuff, since going through a router would cause issues
-			// FIX: i dont know
 			points, isUp, err := applyScoringFunction(
 				team.ID,
 				originalServiceName,
 				boxConfig.Ip,
-				serviceConfig.Port,
-				serviceConfig.BtUsername,
-				serviceConfig.BtPassword,
-				serviceConfig.DBName,
-				serviceConfig.DBPath,
+				serviceConfig,
 			)
 			if err != nil {
 				logger.LogMessage(fmt.Sprintf("Error scoring team %d for service %s: %v", team.ID, service.Name, err), "INFO")
@@ -302,7 +295,7 @@ func getTeamServices(db *sql.DB, teamID int) ([]Service, error) {
 }
 
 // Applies scoring of each service
-func applyScoringFunction(teamID int, serviceName string, baseIP string, port int, username string, password string, dbname string, dbpath string) (int, bool, error) {
+func applyScoringFunction(teamID int, serviceName string, baseIP string, svc config.Service) (int, bool, error) {
 	address, err := constructIPAddress(baseIP, teamID)
 	if err != nil {
 		return 0, false, fmt.Errorf("failed to construct IP address: %w", err)
@@ -311,14 +304,23 @@ func applyScoringFunction(teamID int, serviceName string, baseIP string, port in
 	// Apply the scoring function based on service type
 	switch serviceName {
 	case "ftp":
-		return ScoreFTP("/tests/ftpfiles", address, port, "tests/sshusers/users.txt")
+		return ScoreFTP("tests/ftpfiles", address, svc.Port, "tests/sshusers/users.txt")
 	case "web":
-		return ScoreWeb("/tests/site_infos/site_info.html", address, port)
+		return ScoreWeb("tests/site_infos/site_info.html", address, svc.Port)
 	case "ssh":
-		return ScoreSSH(address, port, "/tests/sshusers/users.txt")
+		return ScoreSSH(address, svc.Port, "tests/sshusers/users.txt")
 	case "db":
-		return ScoreDB(address, port, username, password, dbname, dbpath)
-	// Add cases for other services like web, dns, etc.
+		return ScoreDB(address, svc.Port, svc.BtUsername, svc.BtPassword, svc.DBName, svc.DBPath)
+	case "postgres":
+		return ScorePostgres(address, svc.Port, svc.BtUsername, svc.BtPassword, svc.DBName, svc.DBPath)
+	case "dns_ext_fwd":
+		return ScoreDNSExternalFwd(svc, address+fmt.Sprintf(":%d", svc.Port))
+	case "dns_ext_rev":
+		return ScoreDNSExternalRev(svc, address+fmt.Sprintf(":%d", svc.Port))
+	case "dns_int_fwd":
+		return ScoreDNSInternalFwd(svc, address+fmt.Sprintf(":%d", svc.Port))
+	case "dns_int_rev":
+		return ScoreDNSInternalRev(svc, address+fmt.Sprintf(":%d", svc.Port))
 	default:
 		return 0, false, fmt.Errorf("unknown service %s", serviceName)
 	}
@@ -425,10 +427,8 @@ func ToggleScoring() string {
 
 // Utility function to get the scoring engine's scoring status (on/off)
 func ScoringStatus() string {
-	ScoringOn = !ScoringOn
-	state := "off"
 	if ScoringOn {
-		state = "on"
+		return "on"
 	}
-	return state
+	return "off"
 }

--- a/scoring/ssh.go
+++ b/scoring/ssh.go
@@ -33,7 +33,6 @@ func ChooseRandomUser(dir string) (string, string, error) {
 	}
 
 	// Pick a random line
-	rand.Seed(time.Now().UnixNano()) // Seed RNG once; do it here or in init()
 	randomIndex := rand.Intn(len(validLines))
 	userLine := validLines[randomIndex]
 

--- a/tests/default.yaml
+++ b/tests/default.yaml
@@ -1,6 +1,6 @@
 boxes:
-  ncae-team0-web:
-    ip: 192.168.0.5
+  ncae-web:
+    ip: 192.168.t.5
     services:
       ssh:
         username: "root"
@@ -10,19 +10,10 @@ boxes:
         port: 22
       web:
         port: 80
-  ncae-team1-web:
-    ip: 192.168.1.5
-    services:
-      ssh:
-        username: "root"
-        password: "changeme"
-        bt_username: "blackteam"
-        bt_password: "G^H&J*K(LA@S#D$F%0987f"
-        port: 22
-      web:
-        port: 80
-  ncae-team0-db:
-    ip: 192.168.0.5
+      ftp:
+        port: 21
+  ncae-db:
+    ip: 192.168.t.5
     services:
       db:
         bt_username: "blackteam"
@@ -30,15 +21,31 @@ boxes:
         db_name: "MemeUsers"
         db_path: "tests/schemas/requests.sql"
         port: 3306
-  ncae-team1-db:
-    ip: 192.168.1.5
+  ncae-postgres:
+    ip: 192.168.t.10
     services:
-      db:
+      postgres:
         bt_username: "blackteam"
         bt_password: "G^H&J*K(LA@S#D$F%0987f"
-        db_name: "MemeUsers"
+        db_name: "scoring_data"
         db_path: "tests/schemas/requests.sql"
-        port: 3306
+        port: 5432
+  ncae-dns:
+    ip: 10.20.1.t
+    services:
+      dns_ext_fwd:
+        port: 53
+        query_file: "tests/dnsfiles/domains.txt"
+      dns_ext_rev:
+        port: 53
+        query_file: "tests/dnsfiles/domains.txt"
+      dns_int_fwd:
+        port: 53
+        query_file: "tests/dnsfiles/domains.txt"
+      dns_int_rev:
+        port: 53
+        query_file: "tests/dnsfiles/domains.txt"
+
 teams:
   team0:
     id: 0

--- a/tests/getrefhtml.py
+++ b/tests/getrefhtml.py
@@ -46,13 +46,11 @@ def main():
         # Navigate to your React site at the given IP:port
         driver.get(url)
 
-        # Wait for a known element (#root in many React apps)
+        # Wait for page body to load, then extra sleep for async rendering
         WebDriverWait(driver, 10).until(
-            EC.visibility_of_element_located((By.ID, "root"))
+            EC.presence_of_element_located((By.TAG_NAME, "body"))
         )
-
-        # Extra sleep if the page loads async data
-        time.sleep(2)
+        time.sleep(3)
 
         # Capture the final rendered HTML
         rendered_html = driver.page_source

--- a/tests/getrefhtml.py
+++ b/tests/getrefhtml.py
@@ -26,6 +26,7 @@ def main():
     chrome_options.add_argument("--headless")
     chrome_options.add_argument("--disable-gpu")
     chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--disable-dev-shm-usage")
 
     driver = webdriver.Chrome(
         service=Service(ChromeDriverManager().install()),

--- a/tests/getrefhtml.py
+++ b/tests/getrefhtml.py
@@ -25,8 +25,7 @@ def main():
     chrome_options = Options()
     chrome_options.add_argument("--headless")
     chrome_options.add_argument("--disable-gpu")
-    # If running as root in Docker, you may need:
-    # chrome_options.add_argument("--no-sandbox")
+    chrome_options.add_argument("--no-sandbox")
 
     driver = webdriver.Chrome(
         service=Service(ChromeDriverManager().install()),

--- a/tests/getrefhtml.py
+++ b/tests/getrefhtml.py
@@ -1,3 +1,4 @@
+import shutil
 import sys
 import time
 from selenium import webdriver
@@ -6,7 +7,6 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from webdriver_manager.chrome import ChromeDriverManager
 
 def main():
     if len(sys.argv) < 2:
@@ -28,10 +28,19 @@ def main():
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument("--disable-dev-shm-usage")
 
-    driver = webdriver.Chrome(
-        service=Service(ChromeDriverManager().install()),
-        options=chrome_options
-    )
+    chromedriver_path = shutil.which("chromedriver")
+    if chromedriver_path:
+        driver = webdriver.Chrome(
+            service=Service(chromedriver_path),
+            options=chrome_options
+        )
+    else:
+        # Fall back to webdriver_manager if system chromedriver not found
+        from webdriver_manager.chrome import ChromeDriverManager
+        driver = webdriver.Chrome(
+            service=Service(ChromeDriverManager().install()),
+            options=chrome_options
+        )
 
     try:
         # Navigate to your React site at the given IP:port


### PR DESCRIPTION
## Summary
This PR adds support for PostgreSQL database scoring and DNS service monitoring to the scoring engine, while refactoring the service scoring architecture to be more maintainable and fixing several code quality issues.

## Key Changes

### New Features
- **PostgreSQL Support**: Added `scoring/postgres.go` with `PGconnect()`, `PGverify()`, and `ScorePostgres()` functions to enable PostgreSQL database service scoring alongside existing MySQL support
- **DNS Service Scoring**: Added support for four DNS service types (`dns_ext_fwd`, `dns_ext_rev`, `dns_int_fwd`, `dns_int_rev`) with corresponding scoring functions
- **Test Configuration**: Updated `tests/default.yaml` to include PostgreSQL and DNS service configurations with appropriate test boxes and services

### Refactoring
- **Service Scoring Refactor**: Changed `applyScoringFunction()` signature to accept a `config.Service` struct instead of individual parameters, reducing parameter passing complexity and improving maintainability
- **Path Fixes**: Corrected file paths in scoring functions by removing leading slashes (e.g., `/tests/ftpfiles` → `tests/ftpfiles`)
- **Database Schema**: Added `IF NOT EXISTS` clauses to all CREATE TABLE and CREATE INDEX statements for idempotency

### Code Quality Improvements
- **Fixed `ScoringStatus()` function**: Removed unintended state toggle behavior; now correctly returns current status without modifying it
- **Removed deprecated `rand.Seed()` calls**: Removed manual seeding in `ftp.go` and `ssh.go` (Go 1.20+ handles this automatically)
- **Improved error messages**: Standardized error message formatting in `db.go` (consistent capitalization and format strings)
- **Replaced deprecated imports**: Changed `io/ioutil` to `os` in `database/database.go`
- **Removed dead code**: Eliminated unnecessary file open operation in `DBverify()` function
- **Fixed variable ordering**: Corrected timing measurement in `ScoringStartup()` to capture start time before scoring execution

### Configuration Updates
- Simplified test configuration by consolidating team-specific boxes into single shared boxes with parameterized IPs
- Added FTP service to web box configuration
- Updated database configuration to use PostgreSQL (port 5432) alongside MySQL (port 3306)

## Implementation Details
- PostgreSQL implementation mirrors the existing MySQL database scoring pattern for consistency
- Service configuration is now passed as a struct, allowing easy addition of new service types without modifying function signatures
- DNS scoring functions are called with formatted address:port strings for consistency with other service types

https://claude.ai/code/session_0116EnvakWPsGCMapxnfNvDQ